### PR TITLE
fix:filtering mentors

### DIFF
--- a/apps/web/src/app/(protected)/tutor/leaderboard/_components/leaderBoard.tsx
+++ b/apps/web/src/app/(protected)/tutor/leaderboard/_components/leaderBoard.tsx
@@ -52,6 +52,7 @@ interface Mentor {
   name: string;
   image: string | null;
   mobile: string | null;
+  courseId?:string;
 }
 
 interface CurrentUser {
@@ -162,7 +163,8 @@ const LeaderBoard = ({
 
       <div className="mt-4 flex flex-wrap justify-between items-center gap-4">
         <div className="flex flex-wrap gap-3">
-          {courses?.map((course) => (
+          {courses?.sort((a, b) => a.title.localeCompare(b.title))
+          .map((course) => (
             <button
               hidden={!course.isPublished}
               onClick={() => handleCourseChange(course.id)}
@@ -185,7 +187,7 @@ const LeaderBoard = ({
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="all">All Mentors</SelectItem>
-              {mentors?.map((mentor) => (
+              {mentors?.filter((mentor)=>mentor.courseId==selectedCourse).map((mentor) => (
                 <SelectItem key={mentor.id} value={mentor.username}>
                   {mentor.username}
                 </SelectItem>

--- a/apps/web/src/app/(protected)/tutor/leaderboard/page.tsx
+++ b/apps/web/src/app/(protected)/tutor/leaderboard/page.tsx
@@ -32,6 +32,7 @@ export default async function TutorLeaderboardPage({
   const courses = enrolledCourses
     .map((enrolled) => enrolled.course)
     .filter((course): course is NonNullable<typeof course> => course !== null);
+    
 
   const courseIds = courses.map((course) => course.id);
 
@@ -39,9 +40,8 @@ export default async function TutorLeaderboardPage({
     currentUser.role === "INSTRUCTOR"
       ? await db.enrolledUsers.findMany({
         where: {
-          courseId: {
-            in: courseIds,
-          },
+          courseId:
+          {in:courseIds},
           user: {
             role: "MENTOR",
             organizationId: currentUser.organizationId,
@@ -57,6 +57,12 @@ export default async function TutorLeaderboardPage({
               mobile: true,
             },
           },
+          course:{
+            select:{
+              id:true,
+              title:true
+            }
+          }
         },
         distinct: ["username"],
       })
@@ -134,8 +140,8 @@ export default async function TutorLeaderboardPage({
     name: mentor.user.name,
     image: mentor.user.image,
     mobile: mentor.user.mobile,
+    courseId:mentor.course?.id
   }));
-
   return (
     <Leaderboard
       submissions={sortedSubmissions}


### PR DESCRIPTION
All mentors are shown in the dropdown, regardless of organization. It should only show mentors from the user's organization to avoid confusion. Resolved by fetching the courseId from courses and filtering mentors based on matching courseId to ensure only relevant mentors from the same organization are shown in the dropdown.

