### PR TITLE
fix(runner): match Sandpack test runtime in autoeval sandbox

### DIFF
--- a/.changeset/autoeval-sandbox-parity.md
+++ b/.changeset/autoeval-sandbox-parity.md
@@ -1,0 +1,5 @@
+---
+"runner-orchestrator": patch
+---
+
+Test runtime: swap jsdom→happy-dom and ts-jest→babel-jest (loose mode) so autoeval matches Sandpack's in-browser preview. Fixes `structuredClone is not defined`, `fetch not available`, and spec-strict spread errors for code that passes in the editor.

--- a/apps/runner-orchestrator/Dockerfile.jest
+++ b/apps/runner-orchestrator/Dockerfile.jest
@@ -1,4 +1,3 @@
-# Per-submission Jest sandbox. Spawned by the orchestrator with --network=none.
 FROM node:22-alpine
 
 RUN apk add --no-cache tini
@@ -11,15 +10,18 @@ RUN apk add --no-cache --virtual .build-deps python3 make g++ \
   && rm -rf /root/.npm
 
 COPY apps/runner-orchestrator/runtime/jest.config.cjs ./jest.config.cjs
+COPY apps/runner-orchestrator/runtime/babel.config.cjs ./babel.config.cjs
+COPY apps/runner-orchestrator/runtime/jest.setup.js ./jest.setup.js
 COPY apps/runner-orchestrator/runtime/tsconfig.json ./tsconfig.json
 
-# Symlink baked deps + configs into the orchestrator's mounted /work before running jest.
 RUN printf '%s\n' \
   '#!/bin/sh' \
   'set -e' \
   'cd /work' \
   '[ -e node_modules ] || ln -s /runtime/node_modules node_modules' \
   '[ -e jest.config.cjs ] || ln -s /runtime/jest.config.cjs jest.config.cjs' \
+  '[ -e babel.config.cjs ] || ln -s /runtime/babel.config.cjs babel.config.cjs' \
+  '[ -e jest.setup.js ] || ln -s /runtime/jest.setup.js jest.setup.js' \
   '[ -e tsconfig.json ] || ln -s /runtime/tsconfig.json tsconfig.json' \
   'exec node /runtime/node_modules/.bin/jest "$@"' \
   > /entrypoint.sh \

--- a/apps/runner-orchestrator/runtime/babel.config.cjs
+++ b/apps/runner-orchestrator/runtime/babel.config.cjs
@@ -1,0 +1,14 @@
+module.exports = {
+  presets: [
+    [
+      "@babel/preset-env",
+      {
+        targets: { ie: "11" },
+        loose: true,
+        modules: "commonjs",
+      },
+    ],
+    ["@babel/preset-typescript", { allowDeclareFields: true }],
+    ["@babel/preset-react", { runtime: "automatic" }],
+  ],
+};

--- a/apps/runner-orchestrator/runtime/jest.config.cjs
+++ b/apps/runner-orchestrator/runtime/jest.config.cjs
@@ -1,20 +1,14 @@
 module.exports = {
-  testEnvironment: "jsdom",
-  preset: "ts-jest",
+  testEnvironment: "@happy-dom/jest-environment",
   rootDir: ".",
   roots: ["<rootDir>"],
   testMatch: ["**/*.(test|spec).(ts|tsx|js|jsx)"],
   transform: {
-    "^.+\\.(ts|tsx|js|jsx)$": [
-      "ts-jest",
-      {
-        tsconfig: "<rootDir>/tsconfig.json",
-        diagnostics: false,
-      },
-    ],
+    "^.+\\.(ts|tsx|js|jsx)$": "babel-jest",
   },
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json"],
   modulePathIgnorePatterns: ["<rootDir>/node_modules"],
+  setupFiles: ["<rootDir>/jest.setup.js"],
   testTimeout: 15000,
   maxWorkers: 1,
   cache: false,

--- a/apps/runner-orchestrator/runtime/jest.setup.js
+++ b/apps/runner-orchestrator/runtime/jest.setup.js
@@ -1,0 +1,8 @@
+if (typeof globalThis.structuredClone === "undefined") {
+  const { serialize, deserialize } = require("node:v8");
+  globalThis.structuredClone = (value) => deserialize(serialize(value));
+}
+
+if (typeof globalThis.queueMicrotask === "undefined") {
+  globalThis.queueMicrotask = (cb) => Promise.resolve().then(cb);
+}

--- a/apps/runner-orchestrator/runtime/package.json
+++ b/apps/runner-orchestrator/runtime/package.json
@@ -4,16 +4,21 @@
   "private": true,
   "description": "Prebuilt Jest deps for the runner sandbox image.",
   "dependencies": {
+    "@babel/core": "^7.25.0",
+    "@babel/preset-env": "^7.25.0",
+    "@babel/preset-react": "^7.25.0",
+    "@babel/preset-typescript": "^7.25.0",
+    "@happy-dom/jest-environment": "^15.11.0",
     "@testing-library/jest-dom": "^6.4.6",
     "@testing-library/react": "^16.0.0",
     "@types/jest": "^29.5.12",
+    "@types/node": "^22.0.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "babel-jest": "^29.7.0",
     "jest": "^29.7.0",
-    "jest-environment-jsdom": "^29.7.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "ts-jest": "^29.1.5",
     "typescript": "5.9.3"
   }
 }


### PR DESCRIPTION
## Summary
- Swap `jest-environment-jsdom` → `@happy-dom/jest-environment`: brings native `structuredClone`, `fetch`, modern Web APIs into the per-submission jest sandbox, matching what the Sandpack editor preview sees.
- Swap `ts-jest` → `babel-jest` with `@babel/preset-env` (`loose: true`, `targets: { ie: '11' }`): aligns spread/destructuring semantics with Sandpack's lenient Babel transform, so `[...obj]`-style student code no longer throws in autoeval but pass in editor.
- Wire `babel.config.cjs` + `jest.setup.js` (small structuredClone/queueMicrotask fallbacks) into `Dockerfile.jest`.
- Includes a patch-level changeset for `runner-orchestrator`.

## Why
Students were seeing tests **pass in the Sandpack editor** but **fail in autoeval** with errors like `structuredClone is not defined`, `fetch not available`, and `TypeError: order is not iterable`. Root causes were the same env / transformer asymmetries between Sandpack's iframe-backed runtime and our jsdom@20 + ts-jest setup. After this PR, the failing fixture from the report passes end-to-end in a locally-built jest image under `--network=none`.

## Test plan
- [x] Local: `docker build -f apps/runner-orchestrator/Dockerfile.jest -t tutly-jest-runner:parity-test .`
- [x] Local: ran the shallow-vs-deep-copy fixture under `--network=none` → 2/2 pass
- [ ] CI builds + pushes new jest image
- [ ] Coolify redeploys orchestrator and pulls latest jest image
- [ ] Re-run a previously-failing assignment submission in staging → confirm pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)