### PR TITLE
refactor(storage): drop dual reads/writes — storage is the only source

### DIFF
--- a/apps/web/src/app/api/test-runner/claim/route.ts
+++ b/apps/web/src/app/api/test-runner/claim/route.ts
@@ -50,10 +50,8 @@ export async function POST(req: NextRequest) {
       id: true,
       submissionId: true,
       assignmentId: true,
-      submission: { select: { id: true, data: true, attachmentId: true } },
-      assignment: {
-        select: { ...locatorSelect, sandboxTemplate: true },
-      },
+      submission: { select: { id: true, attachmentId: true } },
+      assignment: { select: locatorSelect },
     },
   });
 
@@ -63,25 +61,15 @@ export async function POST(req: NextRequest) {
 
   const locator = locatorFrom(run.assignment);
   const [submissionFiles, template] = await Promise.all([
-    readSubmission(locator, run.submission.id).catch(() => null),
-    readSandpackTemplate(locator).catch(() => null),
+    readSubmission(locator, run.submission.id),
+    readSandpackTemplate(locator),
   ]);
-
-  const submissionDataMap =
-    submissionFiles ??
-    (run.submission.data && typeof run.submission.data === "object"
-      ? (run.submission.data as Record<string, string>)
-      : {});
 
   // Runner sees full template + submission overrides on visible paths.
   const mergedTemplate = template
-    ? mergeForAudience(
-        template as SandpackTemplate,
-        submissionDataMap,
-        "runner",
-      )
+    ? mergeForAudience(template as SandpackTemplate, submissionFiles, "runner")
     : null;
-  const mergedFiles = mergedTemplate?.files ?? submissionDataMap;
+  const mergedFiles = mergedTemplate?.files ?? submissionFiles ?? {};
 
   return NextResponse.json({
     claimed: true,
@@ -100,7 +88,7 @@ export async function POST(req: NextRequest) {
           ? Buffer.from(JSON.stringify(mergedTemplate), "utf-8").toString(
               "base64",
             )
-          : run.assignment.sandboxTemplate,
+          : null,
       },
     },
   });

--- a/packages/api/src/routers/assignments.ts
+++ b/packages/api/src/routers/assignments.ts
@@ -5,28 +5,16 @@ import { z } from "zod";
 import { locatorFrom, locatorSelect } from "../lib/storage-locator";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
-async function loadSandboxTemplateRaw(assignment: {
-  id: string;
-  sandboxTemplate: string | null;
-}): Promise<string | null> {
-  try {
-    const row = await db.attachment.findUnique({
-      where: { id: assignment.id },
-      select: locatorSelect,
-    });
-    if (row) {
-      const parsed = await readSandpackTemplate(locatorFrom(row));
-      if (parsed != null) {
-        return Buffer.from(JSON.stringify(parsed), "utf-8").toString("base64");
-      }
-    }
-  } catch (err) {
-    console.error("storage read failed for sandboxTemplate", {
-      assignmentId: assignment.id,
-      err,
-    });
-  }
-  return assignment.sandboxTemplate;
+async function loadSandboxTemplateRaw(assignmentId: string): Promise<string | null> {
+  const row = await db.attachment.findUnique({
+    where: { id: assignmentId },
+    select: locatorSelect,
+  });
+  if (!row) return null;
+  const parsed = await readSandpackTemplate(locatorFrom(row));
+  return parsed
+    ? Buffer.from(JSON.stringify(parsed), "utf-8").toString("base64")
+    : null;
 }
 import { defaultWorkspaceConfig } from "../lib/workspace-config";
 import {
@@ -1220,7 +1208,7 @@ export const assignmentsRouter = createTRPCRouter({
             link: assignment.link,
             details: assignment.details,
             detailsJson: assignment.detailsJson,
-            sandboxTemplate: await loadSandboxTemplateRaw(assignment),
+            sandboxTemplate: await loadSandboxTemplateRaw(assignment.id),
             class: {
               id: assignment.class.id,
               title: assignment.class.title,

--- a/packages/api/src/routers/attachments.ts
+++ b/packages/api/src/routers/attachments.ts
@@ -253,23 +253,12 @@ export const attachmentsRouter = createTRPCRouter({
       });
       if (!existing) return { error: "Not found" };
 
-      const templateString = JSON.stringify(parsed.data);
-      const base64Template = Buffer.from(templateString, "utf-8").toString(
-        "base64",
-      );
-      try {
-        await writeSandpackTemplate(locatorFrom(existing), parsed.data);
-      } catch (err) {
-        console.error("storage write failed for sandboxTemplate", { id, err });
-      }
-
+      await writeSandpackTemplate(locatorFrom(existing), parsed.data);
       const attachment = await ctx.db.attachment.update({
         where: { id },
-        data: {
-          sandboxTemplate: base64Template,
-        },
+        data: { updatedAt: new Date() },
+        select: { id: true, updatedAt: true },
       });
-
       return { success: true as const, data: attachment };
     }),
 

--- a/packages/api/src/routers/sandbox.ts
+++ b/packages/api/src/routers/sandbox.ts
@@ -106,25 +106,7 @@ export const sandboxRouter = createTRPCRouter({
         if (locRow) locator = locatorFrom(locRow);
       }
       if (locator) {
-        try {
-          decodedSandboxTemplate = await readSandpackTemplate(locator);
-        } catch (err) {
-          console.error("storage read failed for sandboxTemplate", {
-            assignmentId: resolvedAssignmentId,
-            err,
-          });
-        }
-      }
-      if (decodedSandboxTemplate == null && assignment?.sandboxTemplate) {
-        try {
-          const decoded = Buffer.from(
-            assignment.sandboxTemplate as string,
-            "base64",
-          ).toString("utf-8");
-          decodedSandboxTemplate = JSON.parse(decoded);
-        } catch {
-          decodedSandboxTemplate = assignment.sandboxTemplate;
-        }
+        decodedSandboxTemplate = await readSandpackTemplate(locator);
       }
 
       let resolvedSubmission = submission as
@@ -132,24 +114,9 @@ export const sandboxRouter = createTRPCRouter({
         | null;
       let submissionFiles: Record<string, string> | null = null;
       if (resolvedSubmission && locator) {
-        try {
-          const fromStorage = await readSubmission(locator, resolvedSubmission.id);
-          if (fromStorage) {
-            submissionFiles = fromStorage;
-            resolvedSubmission = { ...resolvedSubmission, data: fromStorage };
-          }
-        } catch (err) {
-          console.error("storage read failed for submission", {
-            submissionId: resolvedSubmission.id,
-            err,
-          });
-        }
-        if (
-          submissionFiles == null &&
-          resolvedSubmission.data &&
-          typeof resolvedSubmission.data === "object"
-        ) {
-          submissionFiles = resolvedSubmission.data as Record<string, string>;
+        submissionFiles = await readSubmission(locator, resolvedSubmission.id);
+        if (submissionFiles) {
+          resolvedSubmission = { ...resolvedSubmission, data: submissionFiles };
         }
       }
 

--- a/packages/api/src/routers/submission.ts
+++ b/packages/api/src/routers/submission.ts
@@ -178,7 +178,7 @@ export const submissionRouter = createTRPCRouter({
       // Load template to validate the submission (no deletions allowed).
       const templateAttachment = await ctx.db.attachment.findUnique({
         where: { id: input.assignmentDetails.id },
-        select: { ...locatorSelect, sandboxTemplate: true },
+        select: locatorSelect,
       });
       const locator = templateAttachment ? locatorFrom(templateAttachment) : null;
       type Template = Awaited<ReturnType<typeof readSandpackTemplate>>;
@@ -186,17 +186,6 @@ export const submissionRouter = createTRPCRouter({
       if (locator) {
         try {
           template = await readSandpackTemplate(locator);
-        } catch {
-          template = null;
-        }
-      }
-      if (!template && templateAttachment?.sandboxTemplate) {
-        try {
-          const decoded = Buffer.from(
-            templateAttachment.sandboxTemplate,
-            "base64",
-          ).toString("utf-8");
-          template = JSON.parse(decoded) as Template;
         } catch {
           template = null;
         }
@@ -212,7 +201,7 @@ export const submissionRouter = createTRPCRouter({
         };
       }
 
-      // Drop hidden/solution paths before storing — server-side enforcement.
+      // Drop hidden/solution/test paths before storing — server-side enforcement.
       const submittedFiles = template
         ? filterSubmissionInput(
             submittedRaw,
@@ -224,8 +213,6 @@ export const submissionRouter = createTRPCRouter({
         data: {
           attachmentId: input.assignmentDetails.id,
           enrolledUserId: enrolledUser.id,
-          // Prisma JSON input type isn't on the browser bundle.
-          data: submittedFiles as never,
           status: "SUBMITTED",
         },
       });
@@ -234,7 +221,7 @@ export const submissionRouter = createTRPCRouter({
         try {
           await writeSubmission(locator, submission.id, submittedFiles);
         } catch (err) {
-          console.error("storage write failed for submission.data", {
+          console.error("storage write failed for submission", {
             submissionId: submission.id,
             err,
           });
@@ -680,44 +667,24 @@ export const submissionRouter = createTRPCRouter({
         });
         if (locRow) {
           const loc = locatorFrom(locRow);
-          let submissionFiles: Record<string, string> | null = null;
-          try {
-            submissionFiles = await readSubmission(loc, submission.id);
-          } catch (err) {
-            console.error("storage read failed for submission", {
-              submissionId: submission.id,
-              err,
-            });
-          }
-          if (
-            submissionFiles == null &&
-            submission.data &&
-            typeof submission.data === "object"
-          ) {
-            submissionFiles = submission.data as Record<string, string>;
-          }
-
-          let template: SandpackTemplate | null = null;
-          try {
-            template = (await readSandpackTemplate(loc)) as SandpackTemplate | null;
-          } catch (err) {
-            console.error("storage read failed for sandboxTemplate", {
-              assignmentId: submission.attachmentId,
-              err,
-            });
-          }
+          const submissionFiles = await readSubmission(loc, submission.id);
+          const template = (await readSandpackTemplate(
+            loc,
+          )) as SandpackTemplate | null;
 
           const audience: "student" | "instructor" = isInstructorAccess
             ? "instructor"
             : "student";
           if (template) {
-            initialFiles = mergeForAudience(template, submissionFiles, audience)
-              .files;
+            initialFiles = mergeForAudience(
+              template,
+              submissionFiles,
+              audience,
+            ).files;
           } else {
             initialFiles = submissionFiles;
           }
         }
-        if (initialFiles == null) initialFiles = submission.data;
 
         return {
           success: true,


### PR DESCRIPTION
## Summary

Storage migration is verified and live in prod (#117). This PR removes the transitional DB-inline-column fallback paths now that the object-storage layer is the source of truth.

**Net change**: +37 / −138 — pure cleanup, mostly removed lines.

## Writes (now storage-only)

- \`attachments.updateAttachmentSandboxTemplate\`: stops writing base64 to \`Attachment.sandboxTemplate\`; the row's \`updatedAt\` is still bumped so cache busters work.
- \`submission.createSubmission\`: stops populating \`submission.data\`. The row exists with its FK + status; files live in storage.

## Reads (no more inline fallback)

- \`sandbox.getSandboxPageData\` — direct storage read, no decode-base64 fallback
- \`submission.createSubmission\` — same for the deletion-check template load
- \`submission.getSubmissionForPlayground\` — merge straight from storage
- \`apps/web/src/app/api/test-runner/claim/route.ts\` — runner gets full template + submission overrides from storage
- \`assignments.loadSandboxTemplateRaw\` — no fallback

## What's NOT in this PR

DB columns stay in the schema as a frozen backup:
- \`Attachment.sandboxTemplate\` (Text)
- \`Attachment.hiddenTestFiles\` (Json?)
- \`submission.data\` (Json?)

Dropping them is a separate \`prisma db push\` follow-up once we're confident nothing reads them.

Migration scripts at \`apps/web/scripts/migrate-to-storage.ts\` and \`verify-storage-end-to-end.ts\` also stay in place — they still work because they read from the DB columns (which remain populated for legacy rows).

## Test plan

- [ ] CI: format / lint / typecheck — all green locally (\`pnpm format:fix && pnpm lint:fix && pnpm typecheck\`)
- [ ] As instructor, save a template → MinIO updates, DB row's \`updatedAt\` bumps, \`Attachment.sandboxTemplate\` column does not change
- [ ] As student, submit → MinIO has a \`submissions/{id}/\` prefix with only editable files; \`submission.data\` is \`null\`
- [ ] Reload sandbox as the student → file map reflects merged view (template + their edits)
- [ ] As instructor, view a submission → sees full template + their submission overrides
- [ ] Runner claim route returns merged \`assignment.sandboxTemplate\` (base64) and \`submission.data\` (merged file map)

🤖 Generated with [Claude Code](https://claude.com/claude-code)