### PR TITLE
fix(api): align submission deletion-check with student-strip filter

### DIFF
--- a/packages/api/src/lib/template-policy.ts
+++ b/packages/api/src/lib/template-policy.ts
@@ -45,7 +45,7 @@ export function isTestPath(p: string): boolean {
   return /\.(test|spec)\.[tj]sx?$/i.test(p);
 }
 
-function isHiddenFromStudent(
+export function isHiddenFromStudent(
   path: string,
   file: SandpackFile | undefined,
 ): boolean {
@@ -54,7 +54,7 @@ function isHiddenFromStudent(
 
 // Wider than hidden — also includes test files (visible to student but
 // owned by the template, never stored per-submission).
-function isTemplateOnly(
+export function isTemplateOnly(
   path: string,
   file: SandpackFile | undefined,
 ): boolean {

--- a/packages/api/src/routers/submission.ts
+++ b/packages/api/src/routers/submission.ts
@@ -18,6 +18,7 @@ import {
 import { locatorFrom, locatorSelect } from "../lib/storage-locator";
 import {
   filterSubmissionInput,
+  isTemplateOnly,
   mergeForAudience,
   type SandpackTemplate,
 } from "../lib/template-policy";
@@ -114,15 +115,10 @@ function findDeletedTemplatePaths(
   const have = new Set(Object.keys(submitted));
   const deleted: string[] = [];
   for (const [path, entry] of Object.entries(files)) {
-    if (/^\/solution(\/|$)/i.test(path) || /\.solution\./i.test(path)) continue;
-    if (
-      typeof entry === "object" &&
-      entry !== null &&
-      "hidden" in entry &&
-      (entry as { hidden?: unknown }).hidden === true
-    ) {
-      continue;
-    }
+    const sf = typeof entry === "string" || (entry && typeof entry === "object")
+      ? (entry as Parameters<typeof isTemplateOnly>[1])
+      : undefined;
+    if (isTemplateOnly(path, sf)) continue;
     if (!have.has(path)) deleted.push(path);
   }
   return deleted;


### PR DESCRIPTION
## Summary

Hotfix for prod outage — submissions silently failing since 2026-05-24.

`createSubmission`'s `findDeletedTemplatePaths` used a narrower inline regex (`/^\/solution(\/|$)/`) than the shared `isSolutionPath` predicate that `filterTemplateForStudent` uses (`/^\/solution(\/|\.|$)/`). The student-view strips `/solution.ts`; the client never sends it back; the server then flagged it as a missing template file and rejected the submission with `{ error: "Cannot delete template files. Restore: /solution.ts" }`. The same gap applied to `/__hidden__/*` paths.

Because the rejection returned `{ error }` from the mutation (HTTP 200, not a tRPC error), the client UI surfaced nothing useful — students saw no toast, no banner.

Every active SANDBOX assignment template in the failing courses contains `/solution.ts`. Zero submissions reached the DB or MinIO for 5 days.

## Fix

Replace the inline check with the shared `isTemplateOnly` predicate (now exported from `template-policy.ts`). `isTemplateOnly` already covers solution paths, `/__hidden__/`, `hidden: true` meta, and test files — exactly the set that `filterTemplateForStudent` strips from the student view and that `filterSubmissionInput` strips from per-submission storage. The three predicates now agree.

## Test plan

- [x] Repro: local script reconstructs Assignment 3.4's template + student-view + submission shape. Old check returns `["/solution.ts"]` (rejects). New check returns `[]` (accepts).
- [x] `/__hidden__/*` template: old rejects, new accepts.
- [x] `hidden: true` meta: both old and new accept (was already correct).
- [x] `tsc --noEmit` on `@tutly/api` passes.
- [ ] Post-merge: verify next real student submission to an Assignment 3.x course lands in DB + MinIO.

## Diff

2 files, +7 / -11. No behavior change for templates without `/solution.ts` or `/__hidden__/*`.